### PR TITLE
Use container id for TRAMP connections in devcontainer-tramp-dired

### DIFF
--- a/devcontainer.el
+++ b/devcontainer.el
@@ -830,21 +830,22 @@ https://containers.dev/implementors/json_reference/#variables-in-devcontainerjso
     (replace-match "\\1\\2")))
 
 ;;;###autoload
-(defun devcontainer-tramp-dired (_container-id container-name remote-user remote-workdir)
+(defun devcontainer-tramp-dired (container-id container-name remote-user remote-workdir)
   "Open a Dired window inside devcontainer's working folder.
 
 When called interactively, all the arguments are determined
 automatically.  The arguments for the non-interactive call are set up in
 a compatible way to `devcontainer-post-startup-hook'.
 
+* CONTAINER-ID – a string representing the container id
 * CONTAINER-NAME – a string representing the container-name
 * REMOTE-USER – a string of the remote user name
 * REMOTE-WORKDIR – the workdir path in the container."
   (interactive
-   (if (not (devcontainer-up-container-id))
-       (user-error "No running devcontainer for current project")
-     (list nil (devcontainer-container-name) (devcontainer-remote-user) (devcontainer-remote-workdir))))
-  (let ((vec (format "/%s:%s@%s:%s" devcontainer-engine remote-user container-name remote-workdir)))
+   (if-let ((container-id (devcontainer-up-container-id)))
+       (list container-id (devcontainer-container-name) (devcontainer-remote-user) (devcontainer-remote-workdir))
+     (user-error "No running devcontainer for current project")))
+  (let ((vec (format "/%s:%s@%s:%s" devcontainer-engine remote-user (or container-id container-name) remote-workdir)))
     (dired vec)))
 
 

--- a/test/devcontainer.el-test.el
+++ b/test/devcontainer.el-test.el
@@ -898,24 +898,28 @@
       (should (equal (devcontainer-remote-workdir) "/workspaces/project/")))))
 
 (ert-deftest devcontainer--tramp-dired-non-interactive-docker-default ()
-  (mocker-let ((dired (path) ((:input '("/docker:user_name@container_name:/workdir/path")))))
+  (mocker-let ((dired (path) ((:input '("/docker:user_name@abc:/workdir/path")))))
     (devcontainer-tramp-dired "abc" "container_name" "user_name" "/workdir/path")))
 
 (ert-deftest devcontainer--tramp-dired-non-interactive-podman ()
   (let ((devcontainer-engine 'podman))
-    (mocker-let ((dired (path) ((:input '("/podman:user_name@container_name:/workdir/path")))))
+    (mocker-let ((dired (path) ((:input '("/podman:user_name@abc:/workdir/path")))))
      (devcontainer-tramp-dired "abc" "container_name" "user_name" "/workdir/path"))))
+
+(ert-deftest devcontainer--tramp-dired-non-interactive-fallback-to-name ()
+  (mocker-let ((dired (path) ((:input '("/docker:user_name@container_name:/workdir/path")))))
+    (devcontainer-tramp-dired nil "container_name" "user_name" "/workdir/path")))
 
 (ert-deftest devcontainer--tramp-dired-devcontainer-not-running ()
   (mocker-let ((devcontainer-up-container-id () ((:output nil))))
     (should-error (call-interactively #'devcontainer-tramp-dired))))
 
 (ert-deftest devcontainer--tramp-dired-devcontainer-is-running ()
-  (mocker-let ((devcontainer-up-container-id () ((:output t)))
+  (mocker-let ((devcontainer-up-container-id () ((:output "auto-container-id")))
                (devcontainer-container-name () ((:output "auto-container-name")))
                (devcontainer-remote-user () ((:output "auto-remote-user")))
                (devcontainer-remote-workdir () ((:output "/auto-remote-workdir")))
-               (dired (path) ((:input '("/docker:auto-remote-user@auto-container-name:/auto-remote-workdir")))))
+               (dired (path) ((:input '("/docker:auto-remote-user@auto-container-id:/auto-remote-workdir")))))
     (call-interactively #'devcontainer-tramp-dired)))
 
 (ert-deftest devcontainer--call-engine-string-sync-null-result ()


### PR DESCRIPTION
Prioritize `container-id` over `container-name` when constructing the TRAMP path. This ensures reliable connections even when the `composeProjectName` returned by the CLI does not match the actual container identifier used by TRAMP.

Fixes #48.