### PR TITLE
Get username from container if remoteUser is not in JSON

### DIFF
--- a/devcontainer.el
+++ b/devcontainer.el
@@ -778,7 +778,8 @@ FILENAME and ARGS are just passed."
 
 (defun devcontainer-remote-user ()
   "Retrieve the remote user name of the current project's devcontainer if it's up."
-  (alist-get 'remoteUser (devcontainer--container-metadata)))
+  (or (alist-get 'remoteUser (devcontainer--container-metadata))
+      (devcontainer--inspect-container "{{.Config.User}}")))
 
 (defun devcontainer-remote-environment ()
   "Retrieve the defined remote environment of current devcontainer if it's up."

--- a/devcontainer.el
+++ b/devcontainer.el
@@ -779,7 +779,9 @@ FILENAME and ARGS are just passed."
 (defun devcontainer-remote-user ()
   "Retrieve the remote user name of the current project's devcontainer if it's up."
   (or (alist-get 'remoteUser (devcontainer--container-metadata))
-      (devcontainer--inspect-container "{{.Config.User}}")))
+      (funcall (lambda (user)
+         (and (not (string= user "")) user))
+       (devcontainer--inspect-container "{{.Config.User}}"))))
 
 (defun devcontainer-remote-environment ()
   "Retrieve the defined remote environment of current devcontainer if it's up."

--- a/test/devcontainer.el-test.el
+++ b/test/devcontainer.el-test.el
@@ -823,8 +823,12 @@
                  (process-lines (cmd &rest args) ((:input '("docker" "container" "inspect"
                                                             "abcdef"
                                                             "--format={{index .Config.Labels \"devcontainer.metadata\"}}")
-                                                   :output '("")))))
-      (should-not (devcontainer-remote-user)))))
+                                                   :output '(""))
+                                                  (:input '("docker" "container" "inspect"
+                                                            "abcdef"
+                                                            "--format={{.Config.User}}")
+                                                   :output '("user_from_container")))))
+      (should (equal (devcontainer-remote-user) "user_from_container")))))
 
 (ert-deftest devcontainer--container-user-container-up-default-engine ()
   (fixture-tmp-dir "test-repo-devcontainer"

--- a/test/devcontainer.el-test.el
+++ b/test/devcontainer.el-test.el
@@ -830,6 +830,19 @@
                                                    :output '("user_from_container")))))
       (should (equal (devcontainer-remote-user) "user_from_container")))))
 
+(ert-deftest devcontainer--remote-user-no-metadata-inspect-empty ()
+  (fixture-tmp-dir "test-repo-devcontainer"
+    (mocker-let ((devcontainer-container-id () ((:output "abcdef")))
+                 (process-lines (cmd &rest args) ((:input '("docker" "container" "inspect"
+                                                            "abcdef"
+                                                            "--format={{index .Config.Labels \"devcontainer.metadata\"}}")
+                                                   :output '(""))
+                                                  (:input '("docker" "container" "inspect"
+                                                            "abcdef"
+                                                            "--format={{.Config.User}}")
+                                                   :output '("")))))
+      (should (equal (devcontainer-remote-user) nil)))))
+
 (ert-deftest devcontainer--container-user-container-up-default-engine ()
   (fixture-tmp-dir "test-repo-devcontainer"
     (mocker-let ((devcontainer-container-id () ((:output "abcdef")))


### PR DESCRIPTION
This should work around issue #51 by using `devcontainer--inspect-container` to read the username from the running Docker container.